### PR TITLE
fix: make stuff work

### DIFF
--- a/__tests__/autocomplete-test.js
+++ b/__tests__/autocomplete-test.js
@@ -58,11 +58,11 @@ describe('<AutocompleteInput />', () => {
       />
     );
 
-    const customInput = autocomplete.find('Text')
+    const customInput = autocomplete.find('Text');
     expect(autocomplete.find('TextInput')).to.have.length(0);
     expect(customInput.children().get(0)).to.equal(text);
     expect(customInput.prop('foo')).to.equal('bar');
-  })
+  });
 
   it('should render default <TextInput /> if no custom one is supplied', () => {
     const autocomplete = shallow(<Autocomplete data={[]} foo="bar" />);
@@ -70,5 +70,5 @@ describe('<AutocompleteInput />', () => {
     const textInput = autocomplete.childAt(0).children().first();
     expect(textInput.name()).to.equal('TextInput');
     expect(textInput.prop('foo')).to.equal('bar');
-  })
+  });
 });

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class Autocomplete extends Component {
      * text input.
      */
     renderItem: PropTypes.func,
-    keyExtractor: PropTypes.func.isRequired,
+    keyExtractor: PropTypes.func,
     /**
      * `renderSeparator` will be called to render the list separators
      * which will be displayed between the list elements in the result view
@@ -105,6 +105,18 @@ class Autocomplete extends Component {
     this.setState({ data });
   }
 
+  onEndEditing(e) {
+    this.props.onEndEditing && this.props.onEndEditing(e);
+  }
+
+  onRefListView(resultList) {
+    this.resultList = resultList;
+  }
+
+  onRefTextInput(textInput) {
+    this.textInput = textInput;
+  }
+
   /**
    * Proxy `blur()` to autocomplete's text input.
    */
@@ -119,10 +131,6 @@ class Autocomplete extends Component {
   focus() {
     const { textInput } = this;
     textInput && textInput.focus();
-  }
-
-  onRefListView(resultList) {
-    this.resultList = resultList;
   }
 
   renderResultList() {
@@ -152,14 +160,6 @@ class Autocomplete extends Component {
         {...flatListProps}
       />
     );
-  }
-
-  onRefTextInput(textInput) {
-    this.textInput = textInput;
-  }
-
-  onEndEditing(e) {
-    this.props.onEndEditing && this.props.onEndEditing(e)
   }
 
   renderTextInput() {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
     "url": "https://github.com/l-urence/react-native-autocomplete-input/issues"
   },
   "homepage": "https://github.com/l-urence/react-native-autocomplete-input#readme",
-  "dependencies": {
-    "prop-types": "^15.6.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "babel-preset-react-native": "^1.9.1",
@@ -52,9 +50,9 @@
     "estraverse-fb": "^1.3.1",
     "mocha": "^3.2.0",
     "nyc": "^10.1.2",
-    "react": "^16.0.0",
+    "react": "~15.5.4",
     "react-addons-test-utils": "^15.6.2",
-    "react-dom": "^16.0.0",
+    "react-dom": "~15.5.4",
     "react-native": "^0.40.0",
     "react-native-mock": "^0.3.1",
     "sinon": "^1.17.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,6 +1734,19 @@ fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.9:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2423,6 +2436,11 @@ js-tokens@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.0.tgz#a2f2a969caae142fb3cd56228358c89366957bd1"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-yaml@^3.5.1:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -2736,6 +2754,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0:
   dependencies:
     js-tokens "^3.0.0"
 
+loose-envify@^1.3.1, loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
 lru-cache@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
@@ -3016,9 +3041,10 @@ object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-is@^1.0.1:
   version "1.0.1"
@@ -3249,6 +3275,23 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.7:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
+prop-types@~15.5.7:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  integrity sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -3319,12 +3362,17 @@ react-addons-pure-render-mixin@^15.4.0:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-addons-test-utils@^15.2.1, react-addons-test-utils@^15.4.0:
+react-addons-test-utils@^15.4.0:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz#93bcaa718fcae7360d42e8fb1c09756cc36302a2"
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
+
+react-addons-test-utils@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
+  integrity sha1-wStu/cIkfBDae4dw0YUICnsEcVY=
 
 react-addons-update@^15.4.0:
   version "15.4.2"
@@ -3341,13 +3389,28 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-react-dom@^15.2.1, react-dom@^15.4.0:
+react-dom@^15.4.0:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
   dependencies:
     fbjs "^0.8.1"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+
+react-dom@~15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
+  integrity sha1-ugwoeG/VLtfk8hNf4CiNRirvk9o=
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "~15.5.7"
+
+react-is@^16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-native-mock@^0.3.1:
   version "0.3.1"
@@ -3465,13 +3528,15 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@~15.4.0-rc.4:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@~15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
+  integrity sha1-+oPrAVBqsjfNwcjDsc6o3gEr8Ec=
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -4073,6 +4138,11 @@ type-is@~1.6.6:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+ua-parser-js@^0.7.18:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
+  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
 ua-parser-js@^0.7.9:
   version "0.7.12"


### PR DESCRIPTION
Thanks for sending https://github.com/mrlaessig/react-native-autocomplete-input/pull/65! I really want it to land, so I decided to look at the failed build.

It started out looking like an innocent linting error, so I added a semicolon and moved the handlers up above the other methods in index.js.

I also ran `yarn` to update the lockfile.

Then I tried to run the tests, which failed because the tests use `react-native-mock`, which uses `React.PropTypes` (instead of the `prop-types` package). React stopped exporting PropTypes in 15.6. It won't be updated as the library is no longer maintained (https://github.com/RealOrangeOne/react-native-mock/issues/139#issuecomment-415121472).

I briefly tried ditching `react-native-mock` altogether and replacing Mocha with Jest to use built-in mocking features, but it seems like newer versions of Jest don't like React Native <0.58, and I didn't want to upgrade react-native all the way from 0.40 or install an old version of Jest.

Thus, I downgraded React from 16 to to `~15.5.4` (which is still an upgrade from `~15.4.0-rc.4`), which got the tests running. Hopefully there wasn't an important reason for bumping to 16…

Finally, I made the `keyExtractor` prop optional, as `FlatList` defaults to checking `item.key` and falls back to using index, like React: https://facebook.github.io/react-native/docs/flatlist#keyextractor

I believe this should work. It's kind of hard to test given that symlinking packages doesn't really work with Metro (https://github.com/facebook/metro/issues/68), but I've copied the entire project into my other project's `node_modules/` and verified that it still works after changing `renderItem` to take `{ item, i }` instead of just `item`, and passing a `key` prop to each item.

I'm pretty sure some docs changes are in order for this one, though—and it will have to be released as a major.

I sure learned a lot about React and React Native from doing this… :smile: